### PR TITLE
[TypeScript] Disallow leading-underscore

### DIFF
--- a/TypeScript/README.md
+++ b/TypeScript/README.md
@@ -14,6 +14,7 @@
 * 변수명은 snake_case가 기본이지만 lowerCamelCase도 허용한다.
 * 상수에 가까운 변수인 경우 UPPER_CASE를 사용한다.
 * PascalCase는 기본적으로 허용하지 않지만, 클래스에 가까운 변수인 경우(예, React의 HOC) 사용할 수 있다.
+* 함수/변수 이름은 _(underscore)로 시작하지 않는다.
 
 ### 기타
 
@@ -102,6 +103,7 @@ const my_obj = {
 ```typescript
 // bad
 const SomeValue = 1;
+const _some_value = 1;
 
 // best
 const some_value = 1;


### PR DESCRIPTION
[Rule: variable-name](https://palantir.github.io/tslint/rules/variable-name/)

우리가 `allow-leading-underscore`을 하고 있지 않기 때문에 변수 명 앞에 underscore를 넣으면 에러가 납니다. 하지만 함수 이름은 적용 안 되는 것 같은데요, 함수 이름에도 leading underscore를 쓰지 않기로 하는 것이 어떨까요? typescript에는 private이 있으므로 굳이 쓸 필요가 없는 것 같습니다.